### PR TITLE
Add per-dataset prompt language

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,22 @@ evaluation:
     - "datasets/dataset1/"
     - "datasets/dataset2/"
   evaluation_method: "box" # 評測方法（支援 "pattern" 或 "box"）
-  system_prompt: | # 系統提示詞，僅於 box 評測方法中使用
-    使用者將提供一個題目，並附上選項 A、B、C、D
-    請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
-    \box{選項}
-    請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
-    務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+  system_prompt:        # 系統提示詞，僅於 box 評測方法中使用
+    zh: |
+      使用者將提供一個題目，並附上選項 A、B、C、D
+      請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
+      \box{選項}
+      請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
+      務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+    en: |
+      The user will provide a question along with options A, B, C, and D.
+      Please read the question carefully and select the option that best fits the requirements.
+      Output the selected option in the following format:
+      \box{Option}
+      Make sure to include only the option within the curly braces; otherwise, it will not be considered a valid answer.
+      Strictly follow the output format and avoid any extra content or incorrect formatting.
+  datasets_prompt_map:
+    "datasets/mmlu/": "en" # 指定資料集使用英文提示詞
   repeat_runs: 5 # 單一 datasets 重複執行次數
   shuffle_options: true # 是否對選項進行隨機排序
 ```
@@ -225,7 +235,13 @@ logging:
       "dataset_path": "datasets/test/", // 評測資料集目錄
       "api_concurrency": 40, // 並行請求數（影響推論速度）
       "evaluation_method": "box", // 評測方式為 box 模式
-      "system_prompt": "以下使用者會給你選擇 A, B, C, D，請你要選出符合題目要求的答案，並且將答案放至 \\box{} 裡面..." // 指定模型回覆格式的提示語
+      "system_prompt": { // 系統提示詞
+        "zh": "...", // 中文提示詞
+        "en": "..."  // 英文提示詞
+      },
+      "datasets_prompt_map": {
+        "datasets/mmlu/": "en"
+      }
     }
   },
   "logging": {

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -19,12 +19,22 @@ evaluation:
     - "datasets/dataset1/"
     - "datasets/dataset2/"
   evaluation_method: "box"  # 評測方法（支援 "pattern" 或 "box"）
-  system_prompt: |          # 系統提示詞，僅於 box 評測方法中使用
-    使用者將提供一個題目，並附上選項 A、B、C、D
-    請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
-    \box{選項}
-    請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
-    務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+  system_prompt:             # 系統提示詞，僅於 box 評測方法中使用
+    zh: |
+      使用者將提供一個題目，並附上選項 A、B、C、D
+      請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
+      \box{選項}
+      請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
+      務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+    en: |
+      The user will provide a question along with options A, B, C, and D.
+      Please read the question carefully and select the option that best fits the requirements.
+      Output the selected option in the following format:
+      \box{Option}
+      Make sure to include only the option within the curly braces; otherwise, it will not be considered a valid answer.
+      Strictly follow the output format and avoid any extra content or incorrect formatting.
+  datasets_prompt_map:
+    "datasets/mmlu/": "en"  # 指定資料集使用英文提示詞
   repeat_runs: 5           # 單一 datasets 重複執行次數
   shuffle_options: true    # 是否對選項進行隨機排序
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -123,7 +123,7 @@ def shuffle_question_options(question_data):
     return new_data
 
 
-def evaluate_file(config, file_path, timestamp):
+def evaluate_file(config, file_path, timestamp, prompt_lang="zh"):
     """評測單一檔案，並輸出詳細結果"""
     data = read_evaluation_data(file_path)
     method = config["evaluation"]["evaluation_method"]
@@ -165,7 +165,7 @@ def evaluate_file(config, file_path, timestamp):
 
             # 在發送API請求前等待
             rate_limiter.wait()
-            future = executor.submit(call_llm_api, config, question_text)
+            future = executor.submit(call_llm_api, config, question_text, prompt_lang)
             future_tasks.append(future)
             future_to_data[future] = (question_text, correct_answer, idx)
 

--- a/llm_api.py
+++ b/llm_api.py
@@ -3,13 +3,19 @@ from logger import log_error
 from openai import OpenAI
 
 
-def call_llm_api(config, question_text):
+def call_llm_api(config, question_text, prompt_lang="zh"):
     """呼叫 LLM API 進行推論"""
 
     # 根據評估方法決定 messages 內容
     if config["evaluation"]["evaluation_method"] == "box":
+        sys_prompt_cfg = config["evaluation"].get("system_prompt", {})
+        if isinstance(sys_prompt_cfg, dict):
+            sys_prompt = sys_prompt_cfg.get(prompt_lang, sys_prompt_cfg.get("zh", ""))
+        else:
+            # 向下相容舊版設定，直接當成字串使用
+            sys_prompt = sys_prompt_cfg
         messages = [
-            {"role": "system", "content": config["evaluation"]["system_prompt"]},
+            {"role": "system", "content": sys_prompt},
             {"role": "user", "content": question_text},
         ]
     else:

--- a/main.py
+++ b/main.py
@@ -41,8 +41,10 @@ if __name__ == "__main__":
         for f in all_files:
             file_accuracies = []
             file_results = []
+            prompt_map = config["evaluation"].get("datasets_prompt_map", {})
+            dataset_lang = prompt_map.get(dataset_path, "zh")
             for run in range(repeat_runs):
-                result = evaluate_file(config, f, f"{start_time}_run{run}")
+                result = evaluate_file(config, f, f"{start_time}_run{run}", dataset_lang)
                 file_accuracies.append(result[1])
                 file_results.append(result)
 


### PR DESCRIPTION
## Summary
- support system prompts in both Chinese and English
- allow selecting prompt language per dataset
- document dataset prompt map usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684160b1c75083248b7492ca33451478